### PR TITLE
Update for Terraform 0.12 compatibility.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,64 +1,20 @@
 module github.com/Preskton/terraform-provider-twilio
 
 require (
-	github.com/agext/levenshtein v1.2.1
-	github.com/apparentlymart/go-cidr v0.0.0-20170616213631-2bd8b58cf427
-	github.com/apparentlymart/go-textseg v1.0.0
-	github.com/armon/go-radix v1.0.0
-	github.com/aws/aws-sdk-go v1.16.6
-	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d
-	github.com/bgentry/speakeasy v0.1.0
-	github.com/blang/semver v0.0.0-20170202183821-4a1e882c79dc
 	github.com/fatih/structs v1.1.0
-	github.com/fatih/structtag v1.0.0
-	github.com/go-stack/stack v1.8.0
-	github.com/golang/protobuf v1.2.0
-	github.com/hashicorp/errwrap v1.0.0
-	github.com/hashicorp/go-cleanhttp v0.5.0
-	github.com/hashicorp/go-getter v0.0.0-20180327010114-90bb99a48d86
-	github.com/hashicorp/go-hclog v0.0.0-20170716174523-b4e5765d1e5f
-	github.com/hashicorp/go-multierror v1.0.0
-	github.com/hashicorp/go-plugin v0.0.0-20180125190438-e53f54cbf51e
-	github.com/hashicorp/go-safetemp v1.0.0
-	github.com/hashicorp/go-uuid v0.0.0-20160120003506-36289988d83c
-	github.com/hashicorp/go-version v1.0.0
-	github.com/hashicorp/hcl v0.0.0-20170504190234-a4b07c25de5f
-	github.com/hashicorp/hcl2 v0.0.0-20180308163058-5f8ed954abd8
-	github.com/hashicorp/hil v0.0.0-20170627220502-fa9f258a9250
-	github.com/hashicorp/terraform v0.11.11
-	github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
-	github.com/inconshreveable/log15 v0.0.0-20180818164646-67afb5ed74ec
-	github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af
-	github.com/kevinburke/go-types v0.0.0-20181103050146-31250f49d75a
-	github.com/kevinburke/go.uuid v1.2.0
-	github.com/kevinburke/rest v0.0.0-20180424040019-54a8b1109595
+	github.com/hashicorp/terraform v0.12.8
+	github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d // indirect
+	github.com/inconshreveable/log15 v0.0.0-20180818164646-67afb5ed74ec // indirect
+	github.com/kevinburke/go-types v0.0.0-20181103050146-31250f49d75a // indirect
+	github.com/kevinburke/go.uuid v1.2.0 // indirect
+	github.com/kevinburke/rest v0.0.0-20180424040019-54a8b1109595 // indirect
 	github.com/kevinburke/twilio-go v0.0.0-20181202201842-113f30c37433
-	github.com/konsorten/go-windows-terminal-sequences v1.0.1
-	github.com/mattn/go-colorable v0.0.9
-	github.com/mattn/go-isatty v0.0.4
-	github.com/mitchellh/cli v0.0.0-20171129193617-33edc47170b5
-	github.com/mitchellh/copystructure v0.0.0-20170525013902-d23ffcb85de3
-	github.com/mitchellh/go-homedir v0.0.0-20161203194507-b8bc1bf76747
-	github.com/mitchellh/go-testing-interface v1.0.0
-	github.com/mitchellh/go-wordwrap v1.0.0
-	github.com/mitchellh/hashstructure v0.0.0-20160209213820-6b17d669fac5
-	github.com/mitchellh/mapstructure v0.0.0-20170307201123-53818660ed49
-	github.com/mitchellh/reflectwalk v0.0.0-20170726202117-63d60e9d0dbc
-	github.com/oklog/run v1.0.0
 	github.com/onsi/ginkgo v1.7.0
 	github.com/onsi/gomega v1.4.3
-	github.com/posener/complete v1.2.1
 	github.com/sirupsen/logrus v1.2.0
-	github.com/ttacon/builder v0.0.0-20170518171403-c099f663e1c2
-	github.com/ttacon/libphonenumber v1.0.1
-	github.com/ulikunitz/xz v0.5.5
-	github.com/zclconf/go-cty v0.0.0-20180302160414-49fa5e03c418
-	golang.org/x/crypto v0.0.0-20180904163835-0709b304e793
-	golang.org/x/net v0.0.0-20181213202711-891ebc4b82d6
-	golang.org/x/sync v0.0.0-20181108010431-42b317875d0f
-	golang.org/x/sys v0.0.0-20181213200352-4d1cda033e06
-	golang.org/x/text v0.3.0
-	google.golang.org/genproto v0.0.0-20181202183823-bd91e49a0898
-	google.golang.org/grpc v1.17.0
-	gopkg.in/mgo.v2 v2.0.0-20180705113604-9856a29383ce
+	github.com/ttacon/builder v0.0.0-20170518171403-c099f663e1c2 // indirect
+	github.com/ttacon/libphonenumber v1.0.1 // indirect
+	gopkg.in/mgo.v2 v2.0.0-20180705113604-9856a29383ce // indirect
 )
+
+replace git.apache.org/thrift.git => github.com/apache/thrift v0.0.0-20180902110319-2566ecd5d999


### PR DESCRIPTION
This change allows the provider to work with Terraform 0.12.8.