### PR TITLE
Update travis to add deploy step.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: go
 go:
   - "1.11.x"
 
-before_install:  
+before_install:
   - go get github.com/mitchellh/gox
 
 # Below from https://gist.github.com/y0ssar1an/df2dab474520c4086926f672c52db139
@@ -22,5 +22,19 @@ notifications:
 
 script:
   - env GO111MODULE=on go build
-  - env GO111MODULE=on gox -osarch="linux/amd64 windows/amd64 darwin/amd64" -output="pkg/{{.OS}}_{{.Arch}}/{{.OS}}-{{.Arch}}-terraform-provider-twilio" .
+  # rename to match terraform provider conventions:
+  #  https://www.terraform.io/docs/configuration/providers.html#third-party-plugins
+  - env GO111MODULE=on gox -osarch="linux/amd64 windows/amd64 darwin/amd64" -output="terraform-provider-twilio_${TRAVIS_TAG}_{{.OS}}_{{.Arch}}" .
   - env GO111MODULE=on go test -v ./...
+
+deploy:
+  provider: releases
+  api_key:
+    secure: YOUR_API_KEY_ENCRYPTED
+  file: terraform-provider-twilio*
+  skip_cleanup: true
+  file_glob: true
+  on:
+    tags: true
+    branch: master
+    go: '1.11.x'


### PR DESCRIPTION
Closes https://github.com/Preskton/terraform-provider-twilio/issues/5.


In order to add the encrypted key: 

Create a personal access token on this page: https://github.com/settings/tokens/new.
* Check the "repo" permission and the permissions underneath it (repo:status, repo_deployment, public_repo)
* Save the key to a `github.key`

Get the public key for this repo:
```
curl -H 'Content-Type: application/json' https://api.travis-ci.org/repos/Preskton/terraform-provider-twilio/key | jq -r '.key' > travis.key
```

```
cat github.key | openssl rsautl -encrypt -inkey travis.key -pubin | base64 
```

References:
https://gist.github.com/openscript/082bd53b28505337510d9e69386b5fc5
https://github.com/travis-ci/travis-ci/issues/2982#issuecomment-358873469
