### PR TITLE
Docs & no arm64 on gorelease

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ go.sum
 
 # since we are now doing go modules
 vendor/
+
+dist/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -24,7 +24,6 @@ builds:
     - amd64
     - '386'
     - arm
-    - arm64
   ignore:
     - goos: darwin
       goarch: '386'
@@ -49,6 +48,6 @@ signs:
       - "${artifact}"
 release:
   # If you want to manually examine the release before its live, uncomment this line:
-  # draft: true
+  draft: true
 changelog:
   skip: true

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,116 @@
+# Twilio Terraform Provider
+
+The goal of this Terraform provider plugin is to make managing your Twilio account easier.
+
+Current features:
+
+- Compatible with Terraform `v0.12.10`+
+- `twilio_phone_number`
+  - Search
+    - Country code
+    - Area Code
+    - Number prefix (or place * wherever you'd like!)
+  - Create/Purchase
+  - Update
+  - Delete/Release
+- `twilio_subaccount`
+  - Create
+  - Update
+  - Delete
+- `twilio_api_key`
+  - Create
+  - Delete
+
+More coming eventually!
+
+## Getting Started
+
+1. Start a trial account at twilio.com (if you don't have one already). Use the Console Dashboard to take note of your Account SID (a long string starts with `AC` and looks like a GUID) and Auth Token (also a long GUID-like string, hidden under the `View` link).
+2. Download the latest release of the provider and place in your `~/.terraform.d/plugins` directory.
+3. Use the example below, replacing `account_sid` and `auth_token` with the appropriate values.
+4. `terraform apply` Note: this will cost you REAL MONEY (or at the very least trial credits).
+
+## Example
+
+Note: running and applying the below could cost you REAL MONEY! Please use this tool wisely!
+
+~> **Important:** You should never check the values for your `account_sid` and `auth_token` into source control, as this would allow others to modify your Twilio account. Instead, source these variables from the environment using the `TF_VAR` style.
+
+```hcl
+provider "twilio" {
+    account_sid = "<your account sid here>"
+    auth_token = "<your auth token here>"
+}
+
+resource "twilio_subaccount" "woomy" {
+    friendly_name = "Woomy Subaccount #1"
+}
+
+resource "twilio_api_key" "woomy" {
+    friendly_name = "Woomy Key #1"
+}
+
+resource "twilio_phone_number" "area_code_test" {
+    // Find a number
+    country_code = "US"
+    area_code = "972"
+    friendly_name = "terraform-provider-twilio area code test number"
+
+    // Configure your number
+
+    address_sid = "ADXXXX"          // Certain countries may require a validated address!
+    identity_sid = "IDXXXX"         // Certain countries may require a validated identity!
+    trunk_sid = "XXXXX"
+
+    voice {
+        primary_url = "https://genoq.com/handlers/voice-primary"
+        primary_http_method = "POST"
+        fallback_url = "https://genoq.com/handlers/voice-fallback"
+        fallback_http_method = "GET"
+        caller_id_enabled = "true"
+        receive_mode = "voice"
+    }
+
+    sms {
+        primary_url = "https://genoq.com/handlers/sms-primary"
+        primary_http_method = "POST"
+        fallback_url = "https://genoq.com/handlers/sms-fallback"
+        fallback_http_method = "GeT"
+    }
+
+    status_callback {
+        url = "https://genoq.com/handlers/status-callback"
+        http_method = "GET"
+    }
+
+    // Note: Emergency calling requires a validated address
+    emergency {
+        address_sid = "ADXXXXX"
+        status = "active"
+    }
+}
+
+resource "twilio_phone_number" "search_test" {
+    country_code = "US"
+    search = "972*"
+    friendly_name = "terraform-provider-twilio by-search test number"
+
+    sms {
+        primary_url = "https://genoq.com/handlers/sms-primary"
+        primary_http_method = "POST"
+        fallback_url = "https://genoq.com/handlers/sms-fallback"
+        fallback_http_method = "GET"
+    }
+
+    voice {
+        receive_mode = "fax"
+        application_sid = "APXXXXX"
+    }
+}
+```
+
+## Disclaimers
+
+~> Important: This is NOT an official Twilio project and is in *no way* supported by Twilio. It is maintained in [Preskton's](https://www.github.com/Preskton) free time.
+
+Released under the Apache 2.0 license. Details available [here](https://github.com/Preskton/terraform-provider-twilio/blob/master/LICENSE).

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,6 @@
 module github.com/Preskton/terraform-provider-twilio
 
 require (
-	github.com/apache/thrift v0.12.0 // indirect
 	github.com/fatih/structs v1.1.0
 	github.com/hashicorp/terraform v0.12.10
 	github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d // indirect
@@ -13,20 +12,15 @@ require (
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
 	github.com/onsi/ginkgo v1.10.2
 	github.com/onsi/gomega v1.7.0
-	github.com/openzipkin/zipkin-go v0.1.6 // indirect
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/cast v1.3.0
-	github.com/stretchr/objx v0.2.0 // indirect
 	github.com/stretchr/testify v1.4.0 // indirect
 	github.com/ttacon/builder v0.0.0-20170518171403-c099f663e1c2 // indirect
 	github.com/ttacon/libphonenumber v1.0.1 // indirect
-	golang.org/x/build v0.0.0-20190111050920-041ab4dc3f9d // indirect
 	golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550 // indirect
 	golang.org/x/net v0.0.0-20191011234655-491137f69257 // indirect
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e // indirect
 	golang.org/x/sys v0.0.0-20191010194322-b09406accb47 // indirect
-	golang.org/x/tools v0.0.0-20191012152004-8de300cfc20a // indirect
-	golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898 // indirect
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	gopkg.in/mgo.v2 v2.0.0-20180705113604-9856a29383ce // indirect
 	gopkg.in/yaml.v2 v2.2.4 // indirect


### PR DESCRIPTION
### What's changing?

- Added docs for Terraform Registry
- Removed `arm64` as part of the goreleaser build. Will add back later.