### PR TITLE
bumped deps + makefile now set up for tf .13 sideload

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,8 @@
+plugin_path := ~/.terraform.d/plugins/sideload.dev/preskton/twilio/0.1.0/linux_amd64
+debug_binary_path := $(plugin_path)/terraform-provider-twilio_something
+
+
+
 .PHONY: build
 build:						## Builds for linux, windows, and darwin
 	export CGO_ENABLED=0
@@ -14,7 +19,9 @@ testacc:					## Run acceptance tests
 
 .PHONY: install
 install: clean build		## Build and reinstall the latest version of the plugin locally
-	cp pkg/linux_amd64/linux-amd64-terraform-provider-twilio ~/.terraform.d/plugins/terraform-provider-twilio
+	mkdir -p $(plugin_path)
+	cp pkg/linux_amd64/linux-amd64-terraform-provider-twilio $(debug_binary_path)
+	chmod +x $(debug_binary_path)
 
 .PHONY: tfplan
 tfplan: install				## Build, install, and run terraform plan

--- a/go.mod
+++ b/go.mod
@@ -1,29 +1,54 @@
 module github.com/Preskton/terraform-provider-twilio
 
 require (
+	cloud.google.com/go v0.64.0 // indirect
+	github.com/Unknwon/com v0.0.0-20151008135407-28b053d5a292 // indirect
+	github.com/agext/levenshtein v1.2.3 // indirect
+	github.com/apparentlymart/go-cidr v1.1.0 // indirect
+	github.com/aws/aws-sdk-go v1.34.9 // indirect
+	github.com/bmatcuk/doublestar v1.3.2 // indirect
+	github.com/dnaeon/go-vcr v0.0.0-20180920040454-5637cf3d8a31 // indirect
+	github.com/fatih/color v1.9.0 // indirect
 	github.com/fatih/structs v1.1.0
-	github.com/hashicorp/terraform v0.12.10
-	github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d // indirect
-	github.com/inconshreveable/log15 v0.0.0-20180818164646-67afb5ed74ec // indirect
-	github.com/kevinburke/go-types v0.0.0-20181103050146-31250f49d75a // indirect
+	github.com/hashicorp/go-hclog v0.14.1 // indirect
+	github.com/hashicorp/go-multierror v1.1.0 // indirect
+	github.com/hashicorp/go-retryablehttp v0.6.7 // indirect
+	github.com/hashicorp/go-uuid v1.0.2 // indirect
+	github.com/hashicorp/go-version v1.2.1 // indirect
+	github.com/hashicorp/golang-lru v0.5.4 // indirect
+	github.com/hashicorp/hcl v1.0.0 // indirect
+	github.com/hashicorp/hcl2 v0.0.0-20190821123243-0c888d1241f6 // indirect
+	github.com/hashicorp/hil v0.0.0-20200423225030-a18a1cd20038 // indirect
+	github.com/hashicorp/logutils v1.0.0 // indirect
+	github.com/hashicorp/terraform v0.13.0
+	github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734 // indirect
+	github.com/hashicorp/yamux v0.0.0-20200609203250-aecfd211c9ce // indirect
+	github.com/inconshreveable/log15 v0.0.0-20200109203555-b30bc20e4fd1 // indirect
+	github.com/kevinburke/go-types v0.0.0-20200309064045-f2d4aea18a7a // indirect
 	github.com/kevinburke/go.uuid v1.2.0 // indirect
-	github.com/kevinburke/rest v0.0.0-20190424050029-77c0c82d0ded // indirect
-	github.com/kevinburke/twilio-go v0.0.0-20190630185733-fe05957cdaf8
-	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
+	github.com/kevinburke/rest v0.0.0-20200429221318-0d2892b400f8 // indirect
+	github.com/kevinburke/twilio-go v0.0.0-20200810163702-320748330fac
+	github.com/marstr/guid v1.1.0 // indirect
+	github.com/mattn/go-colorable v0.1.7 // indirect
+	github.com/mitchellh/cli v1.1.1 // indirect
+	github.com/mitchellh/go-testing-interface v1.14.1 // indirect
+	github.com/mitchellh/mapstructure v1.3.3 // indirect
+	github.com/oklog/run v1.1.0 // indirect
 	github.com/onsi/ginkgo v1.10.2
 	github.com/onsi/gomega v1.7.0
-	github.com/sirupsen/logrus v1.4.2
-	github.com/spf13/cast v1.3.0
-	github.com/stretchr/testify v1.4.0 // indirect
+	github.com/posener/complete v1.2.3 // indirect
+	github.com/sirupsen/logrus v1.6.0
+	github.com/spf13/afero v1.3.4 // indirect
+	github.com/spf13/cast v1.3.1
+	github.com/terraform-providers/terraform-provider-openstack v1.15.0 // indirect
 	github.com/ttacon/builder v0.0.0-20170518171403-c099f663e1c2 // indirect
-	github.com/ttacon/libphonenumber v1.0.1 // indirect
-	golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550 // indirect
-	golang.org/x/net v0.0.0-20191011234655-491137f69257 // indirect
-	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e // indirect
-	golang.org/x/sys v0.0.0-20191010194322-b09406accb47 // indirect
+	github.com/ttacon/libphonenumber v1.1.0 // indirect
+	github.com/ulikunitz/xz v0.5.8 // indirect
+	github.com/vmihailenco/msgpack v4.0.4+incompatible // indirect
+	golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a // indirect
+	golang.org/x/sys v0.0.0-20200821140526-fda516888d29 // indirect
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
-	gopkg.in/mgo.v2 v2.0.0-20180705113604-9856a29383ce // indirect
-	gopkg.in/yaml.v2 v2.2.4 // indirect
+	gopkg.in/mgo.v2 v2.0.0-20190816093944-a6b53ec6cb22 // indirect
 )
 
 replace git.apache.org/thrift.git => github.com/apache/thrift v0.0.0-20180902110319-2566ecd5d999


### PR DESCRIPTION
### What's changing?

- Bumped dependency versions
- Updated `Makefile` to sideload local build during local testing

### How do we know this works?

It builds! It releases!

### Checklist

- [x] I've tagged this PR as a `bug`, `enhancement`, etc.
- [x] I've tested this change locally and it works as expected.
- [x] I've updated any applicable unit/integration tests and they pass locally.
- [ ] I've observed the build passing.
- [ ] THIS CHANGE IS AWESOME AND IT'S READY TO RELEASE!
